### PR TITLE
Add order to Address

### DIFF
--- a/src/Core/AnyStatus.API/Endpoints/Endpoint.cs
+++ b/src/Core/AnyStatus.API/Endpoints/Endpoint.cs
@@ -27,6 +27,7 @@ namespace AnyStatus.API.Endpoints
         }
 
         [Required]
+        [Order(20)]
         public string Address
         {
             get => _address;


### PR DESCRIPTION
When adding more fields to endpoints, the address is always displayed last. This change allows you to place your custom fields before or after the Address field.

Example of field I otherwise couldn't add after the address field:
https://github.com/dotMorten/AnyStatus/blob/1e19256e13ce4edfa4c56277e19395adf8e75a6a/src/Plugins/AnyStatus.Plugins.dotMorten/HomeAssistantEndpoint.cs#L42-L46

![image](https://user-images.githubusercontent.com/1378165/115291859-1b052900-a10a-11eb-996f-bfdd6a652e15.png)
