### PR TITLE
fix getting job status for servers in a subfolder

### DIFF
--- a/src/Plugins/AnyStatus.Plugins.Jenkins/Jobs/JenkinsJobsSource.cs
+++ b/src/Plugins/AnyStatus.Plugins.Jenkins/Jobs/JenkinsJobsSource.cs
@@ -20,12 +20,13 @@ namespace AnyStatus.Plugins.Jenkins.Jobs
             if (source is JenkinsJobWidget widget && !string.IsNullOrEmpty(widget.EndpointId) && _endpointsProvider.GetEndpoint(widget.EndpointId) is JenkinsEndpoint endpoint)
             {
                 var response = await new JenkinsApi(endpoint).GetJobsAsync(default);
+                var endpointUri = new Uri(endpoint.Address.EndsWith('/') ? endpoint.Address : endpoint.Address + '/');
 
                 foreach (var view in response.Views)
                 {
                     foreach (var job in view.Jobs)
                     {
-                        results.Add(new NameValueItem($"{view.Name} > {job.Name}", new Uri(job.URL).PathAndQuery));
+                        results.Add(new NameValueItem($"{view.Name} > {job.Name}", '/' + endpointUri.MakeRelativeUri(new Uri(job.URL)).ToString()));
                     }
                 }
             }


### PR DESCRIPTION
If a server is hosted at http://myserver/jenkins the returned jenkins job list contains urls like http://myserver/jenkins/job/my_job/ just taking the path from this url then combining it later with the endpoint url results in http://myserver/jenkins/jenkins/job/my_job/ which is incorrect